### PR TITLE
fix: correct the Terraform version floors for the examples

### DIFF
--- a/examples/nsg_subnet_association/README.md
+++ b/examples/nsg_subnet_association/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.77 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5 |
 

--- a/examples/nsg_subnet_association/versions.tf
+++ b/examples/nsg_subnet_association/versions.tf
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.5"
 
   required_providers {
     random = {


### PR DESCRIPTION
## Summary

Corrects `required_version` where the declared Terraform floor does not match what the code actually requires.

| `examples/nsg_subnet_association` | `~> 1.0` | `~> 1.5` |

## Why this is wrong today

A consumer on a version *inside* the declared range satisfies the constraint and then hits a hard parse error, so the constraint misleads instead of protecting. `make lint` cannot catch it, because it validates with the `.tool-versions` Terraform rather than the declared floor, and CI runs a recent version that satisfies every floor.

Where an example needs more than the root, the requirement usually comes from a module it **consumes** — most examples use `resource_name`, which declares `~> 1.5`. That is invisible in this repository's own HCL and only appears when the example is initialized.

## The rule being applied

An example must declare **at least** the root's floor, and may declare more. Terraform enforces every `required_version` in the module tree and takes the maximum, so an example declaring less is stating something untrue about itself — but the root should not be dragged up to cover what an example imports, since consumers use the root module. Enforced by `launch-terraform-skeleton#40`.

## Verification

Each directory was loaded with `terraform init -backend=false && validate` using the oldest version its constraint permits, before and after. The full fleet survey covered all 132 converted repos; 23 needed a correction.

READMEs are updated because `terraform-docs` renders `required_version` into the Requirements table and the pre-commit hook fails on a stale one.

## Impact

Not a practical breaking change: nobody below the corrected floor could have been using this successfully, so no working consumer loses anything. Ceilings are unchanged.

Generated with Cursor Agent (Opus 4.8)